### PR TITLE
1.20.4 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.3-SNAPSHOT'
+	id 'fabric-loom' version '1.4-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop/
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.1
-loader_version=0.14.22
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.2
+loader_version=0.15.1
 
 #Fabric api
-fabric_version=0.89.2+1.20.2
+fabric_version=0.91.2+1.20.4
 
 # Mod Properties
-mod_version=0.1.1
+mod_version=0.1.2
 mod_id=threadtweak
 mod_desc=Improve and tweak Minecraft CPU scheduling (again!)
 maven_group=com.github.getchoo

--- a/src/main/java/com/github/getchoo/smoothboot/mixin/UtilMixin.java
+++ b/src/main/java/com/github/getchoo/smoothboot/mixin/UtilMixin.java
@@ -30,10 +30,7 @@ public abstract class UtilMixin {
 	
 	@Shadow @Final @Mutable
 	private static ExecutorService IO_WORKER_EXECUTOR;
-	
-	@Shadow @Final
-	private static AtomicInteger NEXT_WORKER_ID;
-	
+
 	@Shadow
 	private static void uncaughtExceptionHandler(Thread thread, Throwable throwable) {}
 
@@ -73,9 +70,11 @@ public abstract class UtilMixin {
 			SmoothBoot.initConfig = true;
 		}
 
+		AtomicInteger atomicInteger = new AtomicInteger(1);
+
 		return new ForkJoinPool(MathHelper.clamp(select(name, SmoothBoot.config.threadCount.bootstrap,
 			SmoothBoot.config.threadCount.main), 1, 0x7fff), (forkJoinPool) -> {
-				String workerName = "Worker-" + name + "-" + NEXT_WORKER_ID.getAndIncrement();
+				String workerName = "Worker-" + name + "-" + atomicInteger.getAndIncrement();
 				SmoothBoot.LOGGER.debug("Initialized " + workerName);
 
 				ForkJoinWorkerThread forkJoinWorkerThread = new LoggingForkJoinWorkerThread(forkJoinPool, SmoothBoot.LOGGER);
@@ -90,8 +89,10 @@ public abstract class UtilMixin {
 	 * Replace
 	 */
 	private static ExecutorService replIoWorker() {
+		AtomicInteger atomicInteger = new AtomicInteger(1);
+
 		return Executors.newCachedThreadPool((runnable) -> {
-			String workerName = "IO-Worker-" + NEXT_WORKER_ID.getAndIncrement();
+			String workerName = "IO-Worker-" + atomicInteger.getAndIncrement();
 			SmoothBoot.LOGGER.debug("Initialized " + workerName);
 			
 			Thread thread = new Thread(runnable);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
   "depends": {
     "fabricloader": ">=0.14.6",
     "fabric": "*",
-    "minecraft": "1.20.*",
+    "minecraft": "1.20.4",
     "java": ">=17"
   }
 }


### PR DESCRIPTION
- chore: update gradle deps for 1.20.4
- fix: don't use NEXT_WORKER_ID in Util mixin
